### PR TITLE
navbar plumbing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,6 +55,7 @@ data/gdoc*.csv
 data/copy.xls
 data/copy.xlsx
 data/briefing.xlsx
+data/navbar.xlsx
 www/assets/*
 !www/assets/assetsignore
 www/live-data/*

--- a/app_config.py
+++ b/app_config.py
@@ -98,6 +98,9 @@ COPY_PATH = 'data/copy.xlsx'
 BRIEFING_GOOGLE_DOC_KEY = '1cG6itV9fK9Fc7AA_On4ToUgqEWA8Ae5bp0JCxQdtEOw'
 BRIEFING_PATH = 'data/briefing.xlsx'
 
+NAVBAR_GOOGLE_DOC_KEY = '1i0hJX8VZsNLQr6bEnHGWj9wnMBH-_NYeDJrWMdb6Yfo'
+NAVBAR_PATH = 'data/navbar.xlsx'
+
 """
 SHARING
 """

--- a/fabfile/text.py
+++ b/fabfile/text.py
@@ -32,8 +32,9 @@ def update():
         return
 
     get_document(app_config.COPY_GOOGLE_DOC_KEY, app_config.COPY_PATH)
-    get_document(app_config.BRIEFING_GOOGLE_DOC_KEY, app_config.BRIEFING_PATH)
+    get_document(app_config.NAVBAR_GOOGLE_DOC_KEY, app_config.NAVBAR_PATH)
 
+    get_document(app_config.BRIEFING_GOOGLE_DOC_KEY, app_config.BRIEFING_PATH)
     with open('www/data/extra_data/state-briefings.json', 'w') as f:
         copy = copytext.Copy(app_config.BRIEFING_PATH)
         output = copy.json()

--- a/less/navbar.less
+++ b/less/navbar.less
@@ -197,24 +197,27 @@
     	margin:0;
     	list-style-type: none;
     	position: relative;
-        .gotham();
+      .gotham();
 
-        @media @screen-small-above {
-            margin: 0 0 0 5rem;
-        }
+      @media @screen-small-above {
+          margin: 0 0 0 5rem;
+      }
     }
 
     li {
         border-bottom: 1px solid #ddd;
         margin-bottom: 0;
-
+        text-transform: lowercase;
+        p {
+            text-transform: none;
+        }
         @media @screen-small-above {
             float: left;
             width: auto;
             border: none;
         }
-
     }
+
 
     /* State Nav */
     .state-nav {

--- a/render_utils.py
+++ b/render_utils.py
@@ -185,6 +185,7 @@ def make_context(asset_depth=0):
 
     try:
         context['COPY'] = copytext.Copy(app_config.COPY_PATH)
+        context['NAVBAR'] = copytext.Copy(app_config.NAVBAR_PATH)
     except copytext.CopyException:
         pass
 

--- a/templates/_base_parent.html
+++ b/templates/_base_parent.html
@@ -164,6 +164,20 @@
 <script type=text/javascript>
     (function(jQuery) {
         if (typeof jQuery !== 'undefined' && typeof jQuery.getScript === 'function') {
+            var onNavigateMessage = function(url) {
+                var anchor = document.createElement('a');
+                anchor.style.display = 'none';
+                anchor.setAttribute('href', url);
+                document.getElementById('main-section').appendChild(anchor);
+                var evt = new MouseEvent('click', {
+                    view: window,
+                    bubbles: true,
+                    cancelable: true,
+                });
+                anchor.dispatchEvent(evt);
+                anchor.parentNode.removeChild(anchor);
+            }
+
             // add randomness to id to support for multiple graphic instances in one story
             var el = document.getElementById("responsive-embed-{{ slug }}");
             el.id = el.id + "-" + Math.random().toString(36).substr(2,5);
@@ -175,7 +189,7 @@
                         {}
                     );
 
-                    if ({{ slug }} === 'county-results') {
+                    if ('{{ slug }}' === 'county-results') {
                         var getParameterByName = function(name) {
                             name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
                             var regex = new RegExp("[\\?&]" + name + "=([^&#]*)"),
@@ -187,6 +201,8 @@
 
                         pymParent.sendMessage('state-selected', state);
                     }
+
+                    pymParent.onMessage('navigate', onNavigateMessage);
                 });
             });
         } else {
@@ -247,6 +263,20 @@
     </script>
     <script src="//pym.nprapps.org/pym.v1.min.js" type="text/javascript"></script>
     <script>
+        var onNavigateMessage = function(url) {
+            var anchor = document.createElement('a');
+            anchor.style.display = 'none';
+            anchor.setAttribute('href', url);
+            document.getElementById('main-section').appendChild(anchor);
+            var evt = new MouseEvent('click', {
+                view: window,
+                bubbles: true,
+                cancelable: true,
+            });
+            anchor.dispatchEvent(evt);
+            anchor.parentNode.removeChild(anchor);
+        }
+
         if ('{{ slug }}' === 'state-results' || '{{slug}}' === 'state-down-ballot') {
             var getParameterByName = function(name) {
                 name = name.replace(/[\[]/, "\\[").replace(/[\]]/, "\\]");
@@ -254,7 +284,7 @@
                     results = regex.exec(location.search);
                 return results === null ? "" : decodeURIComponent(results[1].replace(/\+/g, " "));
             }
-            var state = getParameterByName('state');     
+            var state = getParameterByName('state');
             var pymParent = new pym.Parent('preview', 'child.html?state=' + state, {
                 id: '{{ slug }}'
             });
@@ -263,6 +293,8 @@
                 id: '{{ slug }}'
             });
         }
+
+        pymParent.onMessage('navigate', onNavigateMessage);
     </script>
 
 </body>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -6,92 +6,32 @@
             <span class="election-name">Election</span>
         </div>
 
+        <input type="checkbox" id="small-screen-nav-checkbox" />
 
-            <input type="checkbox" id="small-screen-nav-checkbox" />
+        <label for="small-screen-nav-checkbox" class="toggle small-screen-nav-label">view results</label>
 
-            <label for="small-screen-nav-checkbox" class="toggle small-screen-nav-label">view results</label>
+        <ul class="menu">
 
-            <ul class="menu">
+            {% for item in NAVBAR.nav %}
+            <li>
+                <a data-relative-href="{{ item.localpath }}" data-seamus-id="{{ item.seamusid }}">{{ item.label }}</a>
+            </li>
+            {% endfor %}
 
-                <li><a href="#">live blog</a></li>
+            <li class="state-nav">
 
-                <li><a href="../board-president">president</a></li>
+                <input type="checkbox" id="state-nav-checkbox" />
+                <label for="state-nav-checkbox" class="state-nav-label">state results </label>
 
-                <li><a href="../board-senate">senate</a></li>
-
-                <li><a href="../board-house">house</a></li>
-
-                <li><a href="../board-governor">governor</a></li>
-
-                <li><a href="../board-ballot">ballot</a></li>
-
-                <li class="state-nav">
-
-                    <input type="checkbox" id="state-nav-checkbox" />
-
-                    <label for="state-nav-checkbox" class="state-nav-label">state results </label>
-
-                    <ul>
-                        <li>
-                        <div class="first-group">
-                            <p><a href="../state-results/?state=al">Alabama</a></p>
-		                    <p><a href="../state-results/?state=ak">Alaska</a></p>
-		                    <p><a href="../state-results/?state=az">Arizona</a></p>
-		                    <p><a href="../state-results/?state=ar">Arkansas</a></p>
-		                    <p><a href="../state-results/?state=ca">California</a></p>
-		                    <p><a href="../state-results/?state=co">Colorado</a></p>
-		                    <p><a href="../state-results/?state=ct">Connecticut</a></p>
-		                    <p><a href="../state-results/?state=de">Delaware</a></p>
-		                    <p><a href="../state-results/?state=dc">D.C.</a></p>
-		                    <p><a href="../state-results/?state=fl">Florida</a></p>
-		                    <p><a href="../state-results/?state=ga">Georgia</a></p>
-		                    <p><a href="../state-results/?state=hi">Hawaii</a></p>
-		                    <p><a href="../state-results/?state=id">Idaho</a></p>
-		                    <p><a href="../state-results/?state=il">Illinois</a></p>
-		                    <p><a href="../state-results/?state=in">Indiana</a></p>
-		                    <p><a href="../state-results/?state=ia">Iowa</a></p>
-		                    <p><a href="../state-results/?state=ka">Kansas</a></p>
+                <ul class="states">
+                    <li>
+                        {% for column in NAVBAR.states|slice(3) %}
+                        <div class="group-{{ loop.index }}">
+                            {% for state in column %}
+                                <p><a data-relative-href="{{ state.relativepath }}" data-seamus-id="{{ state.seamusid }}">{{ state.label }}</a></p>
+                            {% endfor %}
                         </div>
-
-                        <div class="second-group">
-                            <p><a href="../state-results/?state=ky">Kentucky</a></p>
-                            <p><a href="../state-results/?state=la">Louisiana</a></p>
-                            <p><a href="../state-results/?state=me">Maine</a></p>
-                            <p><a href="../state-results/?state=md">Maryland</a></p>
-                            <p><a href="../state-results/?state=ma">Massachusetts</a></p>
-                            <p><a href="../state-results/?state=mi">Michigan</a></p>
-                            <p><a href="../state-results/?state=mn">Minnesota</a></p>
-                            <p><a href="../state-results/?state=ms">Mississippi</a></p>
-                            <p><a href="../state-results/?state=mo">Missouri</a></p>
-                            <p><a href="../state-results/?state=mt">Montana</a></p>
-                            <p><a href="../state-results/?state=ne">Nebraska</a></p>
-                            <p><a href="../state-results/?state=nv">Nevada</a></p>
-                            <p><a href="../state-results/?state=nh">New Hampshire</a></p>
-                            <p><a href="../state-results/?state=nj">New Jersey</a></p>
-                            <p><a href="../state-results/?state=nm">New Mexico</a></p>
-                            <p><a href="../state-results/?state=ny">New York</a></p>
-                            <p><a href="../state-results/?state=nc">North Carolina</a></p>
-                        </div>
-
-                        <div class="third-group">
-                            <p><a href="../state-results/?state=nd">North Dakota</a></p>
-		                    <p><a href="../state-results/?state=oh">Ohio</a></p>
-		                    <p><a href="../state-results/?state=ok">Oklahoma</a></p>
-		                    <p><a href="../state-results/?state=or">Oregon</a></p>
-		                    <p><a href="../state-results/?state=pa">Pennsylvania</a></p>
-		                    <p><a href="../state-results/?state=ri">Rhode Island</a></p>
-		                    <p><a href="../state-results/?state=sc">South Carolina</a></p>
-		                    <p><a href="../state-results/?state=sd">South Dakota</a></p>
-		                    <p><a href="../state-results/?state=tn">Tennessee</a></p>
-		                    <p><a href="../state-results/?state=tx">Texas</a></p>
-		                    <p><a href="../state-results/?state=ut">Utah</a></p>
-		                    <p><a href="../state-results/?state=vt">Vermont</a></p>
-		                    <p><a href="../state-results/?state=vi">Virginia</a></p>
-		                    <p><a href="../state-results/?state=wa">Washington</a></p>
-		                    <p><a href="../state-results/?state=wv">West Virginia</a></p>
-		                    <p><a href="../state-results/?state=wi">Wisconsin</a></p>
-		                    <p><a href="../state-results/?state=wy">Wyoming</a></p>
-                        </div>
+                        {% endfor %}
                     </li>
                 </ul>
             </li>

--- a/templates/navbar.html
+++ b/templates/navbar.html
@@ -14,10 +14,12 @@
 
             {% for item in NAVBAR.nav %}
             <li>
-                <a data-relative-href="{{ item.localpath }}" data-seamus-id="{{ item.seamusid }}">{{ item.label }}</a>
+                <a data-relative-href="{{ item.relativepath }}" data-seamus-id="{{ item.seamusid }}">{{ item.label }}</a>
             </li>
             {% endfor %}
+        </ul>
 
+        <ul>
             <li class="state-nav">
 
                 <input type="checkbox" id="state-nav-checkbox" />
@@ -28,7 +30,7 @@
                         {% for column in NAVBAR.states|slice(3) %}
                         <div class="group-{{ loop.index }}">
                             {% for state in column %}
-                                <p><a data-relative-href="{{ state.relativepath }}" data-seamus-id="{{ state.seamusid }}">{{ state.label }}</a></p>
+                                <p><a href="http://www-s1.npr.org/templates/story/story.php?storyId={{ state.seamusid }}" data-relative-href="{{ state.relativepath }}" data-seamus-id="{{ state.seamusid }}">{{ state.label }}</a></p>
                             {% endfor %}
                         </div>
                         {% endfor %}

--- a/www/js/includes/navbar.js
+++ b/www/js/includes/navbar.js
@@ -1,16 +1,27 @@
 var resultsMenu = document.querySelector(".small-screen-nav-label");
-var stateMenu = document.querySelector(".state-nav-label");
+var stateMenuButton = document.querySelector(".state-nav-label");
+var stateMenu = document.querySelector(".state-nav .states");
 
-resultsMenu.addEventListener("click", function () {
+const updateMenuParent = function(e) {
     // Update iframe
     if (pymChild) {
         setTimeout(pymChild.sendHeight, 0);
     }
-});
+}
 
-stateMenu.addEventListener("click", function () {
-    // Update iframe
-    if (pymChild) {
-        setTimeout(pymChild.sendHeight, 0)
+const followStateMenuLink = function(e) {
+    if (pymChild && pymChild.parentUrl) {
+        if (e.target !== e.currentTarget) {
+            console.log(e.target);
+            console.log(pymChild);
+        }
+        //window.location.href = e.target.getAttribute('data-seamusid');
+    } else {
+        window.location.href = e.target.getAttribute('data-relative-href');
     }
-});
+    e.stopPropagation();
+}
+
+resultsMenu.addEventListener("click", updateMenuParent);
+stateMenuButton.addEventListener("click", updateMenuParent);
+stateMenu.addEventListener("click", followStateMenuLink);

--- a/www/js/includes/navbar.js
+++ b/www/js/includes/navbar.js
@@ -1,6 +1,16 @@
-var resultsMenu = document.querySelector(".small-screen-nav-label");
-var stateMenuButton = document.querySelector(".state-nav-label");
-var stateMenu = document.querySelector(".state-nav .states");
+import URL from 'url-parse';
+
+const parseParentURL = function() {
+    if (!pymChild) {
+        return null;
+    }
+    const parentUrl = new URL(window.pymChild.parentUrl, location, true);
+    if (parentUrl.hostname == '127.0.0.1') {
+        return 'localhost';
+    } else {
+        return parentUrl.hostname.split('.').slice(-2).join('.');
+    }
+}
 
 const updateMenuParent = function(e) {
     // Update iframe
@@ -9,19 +19,31 @@ const updateMenuParent = function(e) {
     }
 }
 
-const followStateMenuLink = function(e) {
-    if (pymChild && pymChild.parentUrl) {
-        if (e.target !== e.currentTarget) {
-            console.log(e.target);
-            console.log(pymChild);
+const followNavLink = function(e) {
+    if (e.target !== e.currentTarget) {
+        if (pymChild) {
+            const domain = parseParentURL();
+            if (domain == 'npr.org') {
+                const seamusid = e.target.getAttribute('data-seamus-id');
+                const url = 'http://www-s1.npr.org/templates/story/story.php?storyId=' + seamusid;
+                pymChild.sendMessage('navigate', url);
+            } else {
+                pymChild.navigateParentTo(e.target.getAttribute('data-relative-href'));
+            }
+        } else {
+            window.location.href = e.target.getAttribute('data-relative-href');
         }
-        //window.location.href = e.target.getAttribute('data-seamusid');
-    } else {
-        window.location.href = e.target.getAttribute('data-relative-href');
     }
+    e.preventDefault();
     e.stopPropagation();
 }
 
-resultsMenu.addEventListener("click", updateMenuParent);
+var resultsMenuButton = document.querySelector(".small-screen-nav-label");
+var resultsMenu = document.querySelector(".menu");
+resultsMenuButton.addEventListener("click", updateMenuParent);
+resultsMenu.addEventListener("click", followNavLink);
+
+var stateMenuButton = document.querySelector(".state-nav-label");
+var stateMenu = document.querySelector(".state-nav .states");
+stateMenu.addEventListener("click", followNavLink);
 stateMenuButton.addEventListener("click", updateMenuParent);
-stateMenu.addEventListener("click", followStateMenuLink);


### PR DESCRIPTION
Adds:

* special navbar spreadsheet and navbar.xlsx context file that provides URL mappings for all navbar items in multiple locations
* special embed code that synthesizes pjax link click on npr.org for pjax (longer term this should be part of the graphics rig / pym loader)

TODO:

* Trickier parts of the station/local/npr.org logic (but only for the liveblog; stations have been advised to roll their own nav if they're running data)
* Synthesized clicks currently require some knowledge of DOM structure of npr.org (attaches to "main section"), needs testing with multiple story layouts
* URL creator currently hardcoded to npr staging site
